### PR TITLE
Fix missing styles and clean up duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.7.0 - 2026-02-24
+
+- Fix: Styles for default content moved to the core stylesheet
+- Breaking: Event slides use `slide.md` or `slide.webc`
+  rather than a specialized `slide.details`
+- New: Default slide accepts `canvas-type` attribute
+- New: `<slide-content>` component renders the default
+  slide title and content blocks
+- New: `<content-block>` component renders `:slide-md` (markdown)
+  and `:slide-webc` (webc/html) content blocks
+
 ## v0.6.0 - 2026-02-05
 
 - Breaking: `[slide-content]` is `position: relative`

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ that accept a variety of properties:
   - `slide.venue` the event title
   - `slide.date` the date of the talk
   - `slide.exit` optional (inline markdown) "back" link in the top
-  - `slide.detail` optional (block markdown) section for more detail
+  - `slide.md` optional (block markdown) section for more detail
 
 - `<todo-slide>` -- for drafting a new talk
   - `slide.todo` markdown block

--- a/components/deck/slide-item.webc
+++ b/components/deck/slide-item.webc
@@ -119,6 +119,11 @@
   [slide-content] {
     font-size: var(--slide-normal-text);
   }
+
+  [slide-md],
+  [slide-webc] {
+    display: contents;
+  }
 }
 
 @layer slide.theme {
@@ -175,6 +180,11 @@
     place-content: var(--slide-place-content, var(---slide-type-place-content));
     place-items: var(--slide-place-items, var(---slide-type-place-items));
     position: relative;
+  }
+
+  [slide-content~=default] {
+    ---slide-type-padding: var(--slide-gap);
+    ---slide-type-place-content: safe center;
   }
 
   slide-caption-wrapper {

--- a/components/partials/content-block.webc
+++ b/components/partials/content-block.webc
@@ -1,0 +1,8 @@
+<div slide-md
+  webc:if="this.slideMd"
+  @html="slideMarkdownBlock(this.slideMd)"
+></div>
+<div slide-webc
+  webc:if="this.slideWebc"
+  @html="this.slideWebc"
+></div>

--- a/components/partials/slide-content.webc
+++ b/components/partials/slide-content.webc
@@ -1,0 +1,21 @@
+<h2
+  webc:if="this.slide.title || this.slide.pre"
+  slide-title="main"
+>
+  <slide-title
+    webc:nokeep
+    :@pre="this.slide.pre"
+    :@title="this.slide.title"
+  ></slide-title>
+</h2>
+<p
+  slide-title="sub"
+  webc:if="this.slide.sub"
+  @html="slideMarkdownInline(this.slide.sub)"
+></p>
+
+<content-block
+  webc:nokeep
+  :@slide-md="this.slide.md"
+  :@slide-webc="this.slide.webc"
+></slide-content>

--- a/components/slide/default-slide.webc
+++ b/components/slide/default-slide.webc
@@ -5,37 +5,12 @@
   :@cite="this.slide.cite"
   :@note="this.slide.note"
   :@slide="this.slide"
+  :@canvas-type="this.canvasType || 'default'"
   :style="slideStyles(this.slide)"
 >
-  <h2 webc:if="this.slide.title || this.slide.pre" slide-title="main">
-    <slide-title
-      webc:nokeep
-      :@pre="this.slide.pre"
-      :@title="this.slide.title"
-    ></slide-title>
-  </h2>
-  <p slide-title="sub" webc:if="this.slide.sub" @html="slideMarkdownInline(this.slide.sub)"></p>
-  <slide-md
-    webc:if="this.slide.md"
-    @html="slideMarkdownBlock(this.slide.md)"
-  ></slide-md>
-  <slide-webc
-    webc:if="this.slide.webc"
-    @html="this.slide.webc"
-  ></slide-webc>
+  <slide-content
+    webc:nokeep
+    :@slide="slide"
+  ></slide-default>
 </slide-item>
 <error-slide webc:nokeep webc:else></error-slide>
-
-<style webc:bucket="slides-core">
-@layer slide.type {
-  [slide-content~=default] {
-    ---slide-type-padding: var(--slide-gap);
-    ---slide-type-place-content: safe center;
-  }
-
-  slide-md,
-  slide-webc {
-    display: contents;
-  }
-}
-</style>

--- a/components/slide/error-slide.webc
+++ b/components/slide/error-slide.webc
@@ -1,14 +1,37 @@
+<script webc:setup>
+  const buildSlideContent = (slide) => {
+    errorSlide = { title: 'Error…' };
+
+    if (slide) {
+      errorSlide.webc = `
+        <pre>${JSON.stringify(slide, null, '\t')}</pre>
+      `;
+    } else {
+      errorSlide.md = `
+        No slide data available
+      `;
+    }
+
+    return errorSlide;
+  }
+</script>
+
 <slide-item
-  @canvas-type="todo"
-  :@slide="this.slide"
+  @canvas-type="error"
+  :@slide="buildSlideContent(this.slide)"
   :@caption="this.slide?.caption"
   :@cite="this.slide?.cite"
   :@note="this.slide?.note"
 >
-  <h2>Error:</h2>
-  <pre
-    webc:if="this.slide"
-    @text="JSON.stringify(this.slide, null, '\t')"
-  ></pre>
-  <p webc:else>No slide data available</p>
+  <slide-content
+    :@slide="this.slide"
+  ></slide-default>
 </slide-item>
+
+<style webc:bucket="slides-core">
+@layer slide.type {
+  [slide-canvas=error] {
+    --slide-canvas-border: medium solid mediumvioletred;
+  }
+}
+</style>

--- a/components/slide/event-slide.webc
+++ b/components/slide/event-slide.webc
@@ -43,11 +43,13 @@
     </header>
 
     <div slide-auto="detail">
-      <template
+      <content-block
+        webc:if="slide.md || slide.webc"
         webc:nokeep
-        webc:if="slide.detail"
-        @html="slideMarkdownBlock(slide.detail)"
-      ></template>
+        :@slide-md="slide.md"
+        :@slide-webc="slide.webc"
+      ></slide-content>
+
       <a
         webc:elseif="$data.slideDeckConfig.domain"
         :href="page.url"

--- a/components/slide/split-slide.webc
+++ b/components/slide/split-slide.webc
@@ -21,16 +21,10 @@
     ></photo-credit>
   </div>
   <div slide-content="default">
-    <h2 webc:if="this.slide.title || this.slide.pre">
-      <slide-title
-        webc:nokeep
-        :@pre="this.slide.pre"
-        :@title="this.slide.title"
-      ></slide-title>
-    </h2>
-    <p class="sub" webc:if="this.slide.sub" @html="slideMarkdownInline(this.slide.sub)"></p>
-    <div webc:if="this.slide.md" @html="slideMarkdownBlock(this.slide.md)"></div>
-    <div webc:if="this.slide.webc" @html="this.slide.webc"></div>
+    <slide-content
+      webc:nokeep
+      :@slide="this.slide"
+    ></slide-default>
   </div>
 </slide-item>
 <error-slide webc:nokeep webc:else></error-slide>

--- a/components/slide/todo-slide.webc
+++ b/components/slide/todo-slide.webc
@@ -1,17 +1,17 @@
-<slide-item
-  @canvas-type="todo"
+<script webc:setup>
+  const buildMDSlide = (slide) => {
+    slide.title = slide.title || 'ToDo…';
+    slide.md = slide.todo;
+    return slide;
+  }
+</script>
+
+<default-slide
+  webc:nokeep
   webc:if="this.slide"
-  :id="this.slide.id"
-  :@caption="this.slide.caption"
-  :@cite="this.slide.cite"
-  :@note="this.slide.note"
-  :@slide="this.slide"
->
-  <h2>Todo:</h2>
-  <div
-    @html="slideMarkdownBlock(this.slide.todo || this.slide)"
-  ></div>
-</slide-item>
+  @canvas-type="todo"
+  :@slide="buildMDSlide(this.slide)"
+></default-slide>
 <error-slide webc:nokeep webc:else></error-slide>
 
 <style webc:bucket="slides-core">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/eleventy-plugin-slide-deck",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
![](https://picsum.photos/600/400?default)

## Description

- Fix: Styles for default content moved to the core stylesheet
- Breaking: Event slides use `slide.md` or `slide.webc`
  rather than a specialized `slide.details`
- New: Default slide accepts `canvas-type` attribute
- New: `<slide-content>` component renders the default
  slide title and content blocks
- New: `<content-block>` component renders `:slide-md` (markdown)
  and `:slide-webc` (webc/html) content blocks