### PR TITLE
Bump version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.8.0 - 2026-04-10
+
+- Breaking: The `slide.title` property is no longer supported
+  in the `<url-slide>` layout, use `layout.source` instead.
+- Breaking: A slide with `slide.title` (or other general content)
+  will prefer the `default` layout over the `url` layout.
+- New: A new `<blank-slide>` is available using `layout:blank`,
+  and can be styled with the `[slide-canvas=blank]` selector.
+
 ## v0.7.0 - 2026-02-24
 
 - Fix: Styles for default content moved to the core stylesheet

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ that accept a variety of properties:
   - `slide.alt` optional alt text for the image
   - `slide.size` controls the screenshot size/dimensions
   - `slide.type` can be set to `og` to use the open-graph API instead
-  - `slide.title` will be added to the caption (and used as alt-fallback)
   - `slide.fit`, & `slide.position` CSS values
 
 - `<quote-slide>`

--- a/components/deck/render-slide.webc
+++ b/components/deck/render-slide.webc
@@ -4,6 +4,12 @@
   :@slide="this.slide"
 ></todo-slide>
 
+<blank-slide
+  webc:elseif="this.slide.layout === 'blank'"
+  webc:nokeep
+  :@slide="this.slide"
+></blank-slide>
+
 <event-slide
   webc:if="this.slide.layout === 'event'"
   webc:nokeep

--- a/components/slide/blank-slide.webc
+++ b/components/slide/blank-slide.webc
@@ -1,0 +1,6 @@
+<default-slide
+  webc:nokeep
+  aria-hidden="true"
+  @canvas-type="blank"
+  :@slide="this.slide"
+></default-slide>

--- a/components/slide/url-slide.webc
+++ b/components/slide/url-slide.webc
@@ -8,7 +8,7 @@
   }
   const buildImgSlide = (slide) => {
     slide.img = urlSrc(slide);
-    slide.alt = slide.alt || slide.title || '';
+    slide.alt = slide.alt || slide.source || '';
     return slide;
   }
 </script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "main": "index.js",
   "publishConfig": {

--- a/utils/slides.js
+++ b/utils/slides.js
@@ -72,17 +72,17 @@ const slideType = (slide) => {
     slide.scss
   ) return 'code';
 
-  const hasGeneral = slide.title
-    || slide.pre || slide.sub
-    || slide.md || slide.webc;
+  const hasTitle = Boolean(slide.title || slide.pre || slide.sub);
+  const hasMarkup = Boolean(slide.md || slide.webc);
 
   if (slide.img) {
-    if (hasGeneral) return 'split';
+    if (hasTitle || hasMarkup) return 'split';
     return 'image'
   }
 
+  if (hasTitle || hasMarkup) return 'default';
+
   if (slide.url) return 'url';
-  if (hasGeneral) return 'default';
   if (slide.name || slide.source || slide.avatar) return 'source';
 
   // error-slide


### PR DESCRIPTION
![](https://picsum.photos/600/400?slide)


## Description

- Breaking: The `slide.title` property is no longer supported
  in the `<url-slide>` layout, use `layout.source` instead.
- Breaking: A slide with `slide.title` (or other general content)
  will prefer the `default` layout over the `url` layout.
- New: A new `<blank-slide>` is available using `layout:blank`,
  and can be styled with the `[slide-canvas=blank]` selector.
