### PR TITLE
Add diff properties and styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - `--slide-line-height`
 - Breaking: Slide colors and type are only used inside the slide canvas
   by default (`--slide-note-font` is not set by default)
+- New: Add `slide.diff-html`, `slide.diff-css`, `slide.diff-js`,
+  and `slide.diff-scss` as first-class languages for code slides.
 
 ## v0.8.0 - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   by default (`--slide-note-font` is not set by default)
 - New: Add `slide.diff-html`, `slide.diff-css`, `slide.diff-js`,
   and `slide.diff-scss` as first-class languages for code slides.
+- Fix: Improve diff styling in provided prism styles
 
 ## v0.8.0 - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ that accept a variety of properties:
   - `slide.live` link a live-code version of the demo, if different
   - `slide.preview` (boolean) set `true` for click-to-load behavior
 - `<code-slide>`
-  - `slide.<language>` (for `html`, `css`, `scss`, or `js`)
+  - `slide.<language>` and `slide.diff-<language>`
+    for `html`, `css`, `scss`, and `js`
   - or `slide.code` and `slide.lang` for any other languages
 - `<support-slide>`
   - `slide.caniuse` feature id for CanIUse

--- a/components/deck/build-deck.webc
+++ b/components/deck/build-deck.webc
@@ -292,22 +292,33 @@
       --slide-code-color-3: oklch(from var(--slide-code-color-1) l c calc(h + 90 * 2));
       --slide-code-color-4: oklch(from var(--slide-code-color-1) l c calc(h + 90 * 3));
 
-      --slide-code-added-light: hsl(120deg 93% 80%);
-      --slide-code-added-dark: hsl(146deg 50% 36%);
-      --slide-code-removed-light: hsl(300deg 76% 72%);
-      --slide-code-removed-dark: hsl(300deg 100% 27%);
+      /* don't love this, but it improves compat significantly */
+      --slide-code-added-light-hsl: 120deg 93% 80%;
+      --slide-code-added-dark-hsl: 146deg 50% 36%;
+      --slide-code-removed-light-hsl: 300deg 76% 72%;
+      --slide-code-removed-dark-hsl: 300deg 100% 27%;
 
-      --slide-code-added-bg: var(--slide-code-added-light);
-      --slide-code-removed-bg: var(--slide-code-removed-light);
+      --slide-code-added-bg: hsl(var(--slide-code-added-light-hsl));
+      --slide-code-added-bg-fade: hsl(var(--slide-code-added-light-hsl) / 0.2);
+      --slide-code-removed-bg: hsl(var(--slide-code-removed-light-hsl));
+      --slide-code-removed-bg-fade: hsl(var(--slide-code-removed-light-hsl) / 0.2);
 
-      @supports (color: light-dark(red, green))  {
+      /* these have the same baseline date */
+      @supports (color: light-dark(red, green))
+        and (color: hsl(from red h s l)) {
         --slide-code-added-bg: light-dark(
-          var(--slide-code-added-light),
-          var(--slide-code-added-dark)
+          hsl(var(--slide-code-added-light-hsl)),
+          hsl(var(--slide-code-added-dark-hsl))
+        );
+        --slide-code-added-bg-fade: hsl(
+          from var(--slide-code-added-bg) h s l / 0.2
         );
         --slide-code-removed-bg: light-dark(
-          var(--slide-code-removed-light),
-          var(--slide-code-removed-dark)
+          hsl(var(--slide-code-removed-light-hsl)),
+          hsl(var(--slide-code-removed-dark-hsl))
+        );
+        --slide-code-removed-bg-fade: hsl(
+          from var(--slide-code-removed-bg) h s l / 0.2
         );
       }
 

--- a/components/deck/build-deck.webc
+++ b/components/deck/build-deck.webc
@@ -292,10 +292,35 @@
       --slide-code-color-3: oklch(from var(--slide-code-color-1) l c calc(h + 90 * 2));
       --slide-code-color-4: oklch(from var(--slide-code-color-1) l c calc(h + 90 * 3));
 
+      --slide-code-added-light: hsl(120deg 93% 80%);
+      --slide-code-added-dark: hsl(146deg 50% 36%);
+      --slide-code-removed-light: hsl(300deg 76% 72%);
+      --slide-code-removed-dark: hsl(300deg 100% 27%);
+
+      --slide-code-added-bg: var(--slide-code-added-light);
+      --slide-code-removed-bg: var(--slide-code-removed-light);
+
+      @supports (color: light-dark(red, green))  {
+        --slide-code-added-bg: light-dark(
+          var(--slide-code-added-light),
+          var(--slide-code-added-dark)
+        );
+        --slide-code-removed-bg: light-dark(
+          var(--slide-code-removed-light),
+          var(--slide-code-removed-dark)
+        );
+      }
+
       .token {
-        &.comment {
+        &.comment,
+        &.coord {
           color: var(--slide-code-color-1);
           font-style: italic;
+        }
+
+        &.coord {
+          /* +++ is a problem */
+          font-variant-ligatures: none;
         }
 
         &.keyword {
@@ -304,14 +329,6 @@
 
         &.parameter {
           color: var(--slide-code-color-4);
-        }
-
-        &.prolog,
-        &.doctype,
-        &.cdata,
-        &.punctuation {
-          color: var(--slide-color);
-          opacity: 0.5;
         }
 
         &.string,
@@ -336,14 +353,31 @@
           font-style: italic;
         }
 
-        &.deleted {
-          background-color: #ffdddd;
-          color: #434343;
+        &.deleted:not(.prefix) {
+          background-color: hsl(from var(--slide-code-removed-bg) h s l / 0.2);
+          opacity: 0.6;
+          text-decoration: line-through;
+          text-decoration-color: var(--slide-color);
+
+          &:hover {
+            text-decoration: unset;
+            opacity: unset;
+          }
+
+          * { filter: grayscale(0.5); }
         }
 
-        &.inserted {
-          background-color: #ddffdd;
-          color: #434343;
+        &.inserted:not(.prefix) {
+          background-color: hsl(from var(--slide-code-added-bg) h s l / 0.2);
+        }
+
+        &.inserted.prefix {
+          background-color: var(--slide-code-added-bg);
+        }
+
+        &.deleted.prefix {
+          background-color: var(--slide-code-removed-bg);
+          filter: none;
         }
 
         &.bold {
@@ -353,6 +387,14 @@
         &.important,
         &.italic {
           font-style: italic;
+        }
+
+        &.prefix,
+        &.prolog,
+        &.doctype,
+        &.cdata,
+        &.punctuation {
+          color: hsl(from var(--slide-color) h s l / 0.6);
         }
       }
     }

--- a/components/slide/code-slide.webc
+++ b/components/slide/code-slide.webc
@@ -1,5 +1,11 @@
 <script webc:setup>
-  const langs = ['html', 'css', 'scss', 'js', 'code'];
+  const langs = [
+    'html', 'diff-html',
+    'css', 'diff-css',
+    'scss', 'diff-scss',
+    'js', 'diff-js',
+    'code',
+  ];
 
   const escapeHtml = (str) => {
     if (typeof str !== 'string') return '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
-  "version": "0.6.0",
+  "version": "0.9.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/eleventy-plugin-slide-deck",
-      "version": "0.6.0",
+      "version": "0.9.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
-  "version": "0.9.0-rc.1",
+  "version": "0.9.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/eleventy-plugin-slide-deck",
-      "version": "0.9.0-rc.1",
+      "version": "0.9.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.9.0-rc.1",
+  "version": "0.9.0-rc.2",
   "type": "module",
   "main": "index.js",
   "publishConfig": {

--- a/test/test-deck.11tydata.slides
+++ b/test/test-deck.11tydata.slides
@@ -246,6 +246,30 @@ JS is also supported as a property,
 if you're into that kind of thing.
 
 <!-- @slide
+diff-html: |
+  -<h1>Support diffs</h1>
+  +<h1>Support first-class diffs</h1>
+   <p>
+    Using the <code>slide.diff-html</code> property
+    for example.
+   </p>
+diff-css: |
+  --- useful to have metadata here
+  +++ when the first-line is not a change
+  @@ and starts with a space @@
+
+   .language-diff-css {
+  -  /* along with styles */
+  +  /* with improved styles */
+     color: green;
+   }
+-->
+
+Support for
+`slide.diff-html`, `slide.diff-css`, `slide.diff-js`, and `slide.diff-scss`
+properties for code slides.
+
+<!-- @slide
 escapeHtml: true
 lang: www-styles
 code: |

--- a/utils/slides.js
+++ b/utils/slides.js
@@ -67,9 +67,10 @@ const slideType = (slide) => {
   if (slide.quote) return 'quote';
   if (slide.pen) return 'pen';
   if (
-    slide.code ||
-    slide.html || slide.css || slide.js ||
-    slide.scss
+    slide.code
+    || slide.html || slide.css || slide.js || slide.scss
+    || slide['diff-html'] || slide['diff-css']
+    || slide['diff-js'] || slide['diff-scss']
   ) return 'code';
 
   const hasTitle = Boolean(slide.title || slide.pre || slide.sub);


### PR DESCRIPTION
![](https://picsum.photos/600/400?diff)

## Description

Add diff styles for code slides.

We discussed this some in slack, mostly landing on faded and crossed-out deletions. Which was good for the specific use-case I asked about. But it seemed to me like diffs should also be able to show additions - so I brought some color back into the mix. Feel free to propose adjustments. 

<img width="652" height="450" alt="Screenshot 2026-05-13 at 12 12 42 PM" src="https://github.com/user-attachments/assets/d5089954-a5e6-422b-9efe-10d809730496" />
<img width="651" height="449" alt="Screenshot 2026-05-13 at 12 12 54 PM" src="https://github.com/user-attachments/assets/5b83bf0a-004a-4fc8-ad9d-0be6585524e4" />
