### PR TITLE
Use container queries for slideshow height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.1 - UNRELEASED
+## v0.9.1 - 2026-05-26
 
 - Fix: Use `@container` rather than `@media`
   for determining when slides can be full-height

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.1 - UNRELEASED
+
+- Fix: Use `@container` rather than `@media`
+  for determining when slides can be full-height
+  rather than using an aspect-ratio.
+
 ## v0.9.0 - 2026-05-15
 
 - Breaking: Remove default `box-sizing` and only apply where needed

--- a/components/deck/build-deck.webc
+++ b/components/deck/build-deck.webc
@@ -62,32 +62,28 @@
     grid-template-columns: repeat(auto-fill, minmax(min(35ch, 100%), 1fr));
     font-size: var(--slide-small-text);
 
-    [slide-item='container'] {
+    [slide-item=container] {
       align-items: start;
       grid-template-rows: auto 1fr;
     }
   }
 
   [slide-view=slideshow] {
-    @media (orientation: landscape) {
-      --slide-ratio: unset;
-      --slide-content-height: minmax(0, 1fr);
-
-      [slide-item=container] {
-        grid-template-rows: 100svh;
-      }
-    }
-
-    @media (orientation: portrait) {
-      [slide-item=container] {
-        display: unset;
-      }
+    [slide-item=container] {
+      grid-template-columns: minmax(0, 1fr);
+      container: slide / inline-size;
     }
 
     [slide-canvas] {
       border: 0;
       border-block-end: thin solid var(--slide-border-color);
       scroll-snap-align: start;
+
+      @container slide (inline-size > 100cqb) {
+        --slide-ratio: initial;
+        --slide-content-height: minmax(0, 1fr);
+        block-size: 100cqb;
+      }
     }
 
     [slide-note] {
@@ -104,7 +100,7 @@
       display: grid;
       grid-template-columns: min(15em, 30%) 1fr;
 
-      [slide-item='container'] {
+      [slide-item=container] {
         grid-template-columns: subgrid;
 
         &:last-of-type {
@@ -120,7 +116,7 @@
       }
     }
 
-    [slide-item='container'] {
+    [slide-item=container] {
       align-items: center;
       grid-column: 1 / -1;
       z-index: var(--slide-z, initial);
@@ -142,7 +138,7 @@
       padding-inline: var(--slide-gap);
     }
 
-    [aria-current='true'] {
+    [aria-current=true] {
       --note-font-size: 120%;
       --note-visibility: visible;
       --canvas-opacity: 1;

--- a/components/slide/event-slide.webc
+++ b/components/slide/event-slide.webc
@@ -62,7 +62,7 @@
 
 <style webc:bucket="slides-core">
 @layer slide.type {
-  [slide-content='event'] {
+  [slide-content=event] {
     ---slide-type-padding: var(--slide-gap);
     display: flex;
     flex-direction: column;

--- a/components/slide/split-slide.webc
+++ b/components/slide/split-slide.webc
@@ -31,7 +31,7 @@
 
 <style webc:bucket="slides-core">
 @layer slide.type {
-  [slide-content='split'] {
+  [slide-content=split] {
     --slide-image-clip: polygon(
       0 0, 100% 0,
       calc(100% - 5cqi) 100%,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
-  "version": "0.9.1-beta.1",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/eleventy-plugin-slide-deck",
-      "version": "0.9.1-beta.1",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
-  "version": "0.9.0",
+  "version": "0.9.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/eleventy-plugin-slide-deck",
-      "version": "0.9.0",
+      "version": "0.9.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.9.0",
+  "version": "0.9.1-beta.1",
   "type": "module",
   "main": "index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.9.1-beta.1",
+  "version": "0.9.1",
   "type": "module",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
![](https://picsum.photos/600/400?doesthisdoanything)


## Description

Previously, we used the media orientation to determine if a slide-show should make slides fit the screen. This switches to using container queries for that same purpose – allowing the slide-deck to work similarly in nested situations.
