### PR TITLE
Allow setting slide-deck attrs from build-deck component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.10.0 - 2026-07-02
+
+- Breaking: Allow setting `slide-view`, `key-control`, and `follow-active`
+  attributes when calling the `<build-deck>` component.
+  The default `slide-view` is still `article`,
+  but the others have been removed by default.
+
 ## v0.9.1 - 2026-05-26
 
 - Fix: Use `@container` rather than `@media`

--- a/components/deck/build-deck.webc
+++ b/components/deck/build-deck.webc
@@ -1,10 +1,12 @@
 <slide-deck
   webc:import="npm:@oddbird/slide-deck"
-  :id="this.id || 'slides'"
+  @attributes="({
+    id: this.id || 'slides',
+    'slide-view': this.slideView || 'article',
+    'key-control': this.keyControl,
+    'follow-active': this.followActive,
+  })"
   :@slides="this.slides"
-  slide-view="article"
-  key-control
-  follow-active
 >
   <slot></slot>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oddbird/eleventy-plugin-slide-deck",
   "description": "Build customizable presentations in eleventy",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "main": "index.js",
   "publishConfig": {

--- a/test/_layouts/base.webc
+++ b/test/_layouts/base.webc
@@ -19,3 +19,17 @@
   <script @raw="getBundle('js')" webc:keep></script>
 </body>
 </html>
+
+<style>
+  html {
+    color-scheme: light dark;
+
+    &:has(option[value=light-mode]:checked) {
+      color-scheme: light;
+    }
+
+    &:has(option[value=dark-mode]:checked) {
+      color-scheme: dark;
+    }
+  }
+</style>

--- a/test/_layouts/page.webc
+++ b/test/_layouts/page.webc
@@ -1,8 +1,18 @@
 ---
-layout: template
+layout: base
 ---
 
-<template webc:nokeep @raw="this.content"></template>
+<main @raw="this.content"></main>
+<footer>
+  <label for="color-scheme">Color Scheme</label>
+  <select id="color-scheme">
+    <option value="auto-mode">Auto</option>
+    <option value="light-mode">Light</option>
+    <option value="dark-mode">Dark</option>
+  </select>
+</footer>
+
 <style>
   main { margin: 1em; }
+  footer { padding: 1em; }
 </style>

--- a/test/_layouts/slides.webc
+++ b/test/_layouts/slides.webc
@@ -5,6 +5,9 @@ layout: template
 <build-deck
   webc:nokeep
   id="my-very-good-talk"
+  :@slide-view="this.slideView"
+  :@key-control="this.keyControl"
+  :@follow-active="this.followActive"
   :@slides="this.slideDeck"
 >
   <default-slide

--- a/test/_layouts/template.webc
+++ b/test/_layouts/template.webc
@@ -3,26 +3,3 @@ layout: base
 ---
 
 <main @raw="this.content"></main>
-<footer>
-  <label for="color-scheme">Color Scheme</label>
-  <select id="color-scheme">
-    <option value="auto-mode">Auto</option>
-    <option value="light-mode">Light</option>
-    <option value="dark-mode">Dark</option>
-  </select>
-</footer>
-
-<style>
-  html {
-    color-scheme: light dark;
-
-    &:has(option[value=light-mode]:checked) {
-      color-scheme: light;
-    }
-
-    &:has(option[value=dark-mode]:checked) {
-      color-scheme: dark;
-    }
-  }
-  footer { padding: 1em; }
-</style>

--- a/test/test-deck.md
+++ b/test/test-deck.md
@@ -2,4 +2,5 @@
 layout: slides
 title: A test page with all the slide types
 slotTest: true
+keyControl: true
 ---

--- a/test/test-two.deck
+++ b/test/test-two.deck
@@ -1,6 +1,7 @@
 ---
 title: Using the `*.deck` Template Format
 layout: slides
+keyControl: true
 ---
 
 Hello world


### PR DESCRIPTION
![](https://picsum.photos/600/400?attrs)


## Description

Previously, the `key-control` and `follow-active` attributes were hardwired. This allows setting them when calling the build-deck component.

fixes #41 